### PR TITLE
Automatically synchronize `VERSION` file with Release tag name

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -11,6 +11,20 @@ jobs:
         steps:
             - name: Checkout branch
               uses: actions/checkout@v4
+            - name: Sychronize `VERSION` file with Git tag
+              # Get the Git tag name (e.g. "v1.2.3") associated with the GitHub Release,
+              # strip away the leading "v", and write the remainder to the `VERSION` file.
+              #
+              # Note: If the Git tag name doesn't start with a "v" followed by a number,
+              #       we just write the entire Git tag name to the `VERSION` file.
+              #
+              # Note: In bash, `[[ condition ]] && command1 || command2` is a form of if/then/else.
+              #       Also, in bash, `${BASH_REMATCH[1]}` contains the first regex capture group.
+              #
+              run: |
+                TAG_NAME='${{ github.ref_name }}'
+                [[ "${TAG_NAME}" =~ ^v([0-9].*) ]] && VERSION="${BASH_REMATCH[1]}" || VERSION="${TAG_NAME}"
+                echo "${VERSION}" > ./VERSION
             - name: Authenticate with container registry
               uses: docker/login-action@v3
               with:

--- a/README.md
+++ b/README.md
@@ -45,15 +45,13 @@ Here's how you can run the tests:
 
 Here's how you can build a new version of the container image and push it to the [GitHub Container Registry](https://github.com/microbiomedata/nmdc-aggregator/pkgs/container/nmdc-aggregator):
 
-1. Update the version number in the `VERSION` file.
-   > Use "[`major.minor.patch`](https://semver.org/)" format (e.g. "`1.2.3`").
-2. On GitHub, create a new Release.
+1. On GitHub, create a new Release.
     1. Create a tag.
-       > Name it "`v`" followed by the version number in the `VERSION` file (e.g. "`v1.2.3`").
+       - Use "[`v{major}.{minor}.{patch}`](https://semver.org/)" format (e.g. "`v1.2.3`").
     2. Click the "Generate release notes" button.
     3. Leave the Release title empty (so GitHub reuses the tag name as the Release title).
     4. Click the "Publish release" button.
-3. Wait 3-4 minutes for the container image to appear on the [GitHub Container Registry](https://github.com/microbiomedata/nmdc-aggregator/pkgs/container/nmdc-aggregator).
+2. Wait 3-4 minutes for the container image to appear on the [GitHub Container Registry](https://github.com/microbiomedata/nmdc-aggregator/pkgs/container/nmdc-aggregator).
    > Taking a long time? Check the "Actions" tab on GitHub to see the status of the GitHub Actions workflow that builds the image.
 
 Now that the container image is hosted there, you can configure a Spin workload to run it.

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,9 @@
-1.0.8
+# You can leave this set to "0.0.0" in the repository.
+#
+# Note: Whenever someone publishes a GitHub Release of this repository,
+#       the GitHub Actions workflow that builds and publishes a new
+#       container image will update this file in the container image
+#       so it contains the Git tag name associated with the Release
+#       (it will typically omit the leading "v" character).
+#
+0.0.0


### PR DESCRIPTION
In this branch, I made it so the `VERSION` file in the published container image always matches the Git tag associated with the GitHub Release whose creation triggered the building and publishing of that container image.