### PR TITLE
Fix handling of MetaP functional annotation after reworking razor protein logic

### DIFF
--- a/generate_metap_agg.py
+++ b/generate_metap_agg.py
@@ -348,8 +348,8 @@ class MetaProtAgg(Aggregator):
         self.aggregation_filter = '{"was_generated_by":{"$regex":"^nmdc:wfmp"}}'
         self.workflow_filter = '{"type":"nmdc:MetaproteomicsAnalysis"}'
     
-    def get_functional_terms_from_protein_report(self, url):
-        """Function to get the functional terms from a URL of a Protein Report
+    def get_functional_terms_from_peptide_report(self, url):
+        """Function to get the functional terms from a URL of a Peptide Report
 
         Parameters
         ----------
@@ -359,11 +359,15 @@ class MetaProtAgg(Aggregator):
         Returns
         -------
         dict
-            Dictionary of KEGG, COG, and PFAM terms with their respective spectral counts derived from the Protein Report
+            Dictionary of KEGG, COG, and PFAM terms with their respective spectral counts derived from the Peptide Report
         """
-        # Parse the Peptide Report content into KO, COG, and Pfam terms
+        # Parse the Peptide Report content
         content_pep = self.read_url_tsv(url)
+
+        # Initialize the dictionary to store the peptide annotations for each peptide sequence
         pep_dict = {}
+
+        # Loop through the Peptide Report content and populate the dictionary for each peptide sequence
         for line in content_pep:
             peptide_sequence = line.get("peptide_sequence")
             
@@ -373,9 +377,10 @@ class MetaProtAgg(Aggregator):
                 pep_dict[peptide_sequence]["spectral_counts"] = int(float(line.get("peptide_spectral_count")))
                 pep_dict[peptide_sequence]["annotations"] = []
             
+            # Get the annotations for the peptide sequence
             annotations = []
 
-            # Add ko terms to the dictionary
+            # Add ko terms to annotations list
             ko = line.get("KO")
             if ko != "" and ko is not None:
                 for ko_term in ko.split(","):
@@ -383,24 +388,24 @@ class MetaProtAgg(Aggregator):
                     ko_clean = ko_term.replace("KO:", "KEGG.ORTHOLOGY:").strip()
                     annotations.append(ko_clean)
 
-            # Add cog terms to the dictionary
+            # Add cog terms to annotations list
             cog = line.get("COG")
             if cog != "" and cog is not None:
                 for cog_term in cog.split(","):
                     cog_clean = "COG:" + cog_term.strip()
                     annotations.append(cog_clean)
 
-            # Add pfam terms to the dictionary
+            # Add pfam terms to annotations list
             pfam = line.get("pfam")
             if pfam != "" and pfam is not None:
                 for pfam_term in pfam.split(","):
                     pfam_clean = "PFAM:" + pfam_term.strip()
                     annotations.append(pfam_clean)
             
-            # Add the annotations to the dictionary
+            # Add the annotations to the peptide sequence dictionary
             pep_dict[peptide_sequence]["annotations"] = list(set(pep_dict[peptide_sequence]["annotations"] + annotations))
         
-        # Collapse the peptide annotations to the protein level
+        # Collapse the peptide annotations to the functional annotation level
         pep_fxns = {}
         # loop through the peptides and add the annotations and spectral counts to the functional annotations dictionary
         for pep_seq, pep_single_dict in pep_dict.items():
@@ -408,39 +413,6 @@ class MetaProtAgg(Aggregator):
                 pep_fxns = self.add_to_dict(pep_fxns, annotation, pep_single_dict["spectral_counts"])
 
         return pep_fxns
-
-    def find_protein_report_url(self, dos):
-        """Find the URL for the protein report from a list of data object IDs
-
-        Parameters
-        ----------
-        dos : list
-            List of data object IDs
-
-        Returns
-        -------
-        str
-            URL for the Protein Report data object if found
-        """
-        url = None
-
-        # Get all the data object records
-        id_filter = '{"id": {"$in": ["' + '","'.join(dos) + '"]}}'
-        do_recs = self.get_results(
-            collection="data_object_set",
-            filter=id_filter,
-            max_page_size=1000,
-            fields="id,data_object_type,url",
-        )
-
-        # Find the Protein Report data object and return the URL to access it
-        for do in do_recs:
-            if do.get("data_object_type") == "Protein Report":
-                url = do.get("url")
-                return url
-
-        # If no Protein Report data object is found, return None
-        return None
 
     def find_peptide_report_url(self, dos):
         """Find the URL for the peptide report from a list of data object IDs
@@ -496,7 +468,7 @@ class MetaProtAgg(Aggregator):
             raise ValueError(f"Missing url for {act['id']}")
 
         # Parse the KEGG, COG, and PFAM annotations
-        return self.get_functional_terms_from_protein_report(url)
+        return self.get_functional_terms_from_peptide_report(url)
 
 
 if __name__ == "__main__":

--- a/generate_metap_agg.py
+++ b/generate_metap_agg.py
@@ -349,27 +349,27 @@ class MetaProtAgg(Aggregator):
                 # Replace KO: with KEGG.ORTHOLOGY:
                 ko_clean = ko.replace("KO:", "KEGG.ORTHOLOGY:")
                 if ko_clean not in fxns.keys():
-                    fxns[ko_clean] = int(line.get("SummedSpectraCounts"))
+                    fxns[ko_clean] = int(float(line.get("SummedSpectraCounts")))
                 else:
-                    fxns[ko_clean] += int(line.get("SummedSpectraCounts"))
+                    fxns[ko_clean] += int(float(line.get("SummedSpectraCounts")))
 
             # Add cog terms to the dictionary
             cog = line.get("COG")
             if cog != "" and cog is not None:
                 cog_clean = "COG:" + cog
                 if cog_clean not in fxns.keys():
-                    fxns[cog_clean] = int(line.get("SummedSpectraCounts"))
+                    fxns[cog_clean] = int(float(line.get("SummedSpectraCounts")))
                 else:
-                    fxns[cog_clean] += int(line.get("SummedSpectraCounts"))
+                    fxns[cog_clean] += int(float(line.get("SummedSpectraCounts")))
 
             # Add pfam terms to the dictionary
             pfam = line.get("pfam")
             if pfam != "" and pfam is not None:
                 pfam_clean = "PFAM:" + pfam
                 if pfam_clean not in fxns.keys():
-                    fxns[pfam_clean] = int(line.get("SummedSpectraCounts"))
+                    fxns[pfam_clean] = int(float(line.get("SummedSpectraCounts")))
                 else:
-                    fxns[pfam_clean] += int(line.get("SummedSpectraCounts"))
+                    fxns[pfam_clean] += int(float(line.get("SummedSpectraCounts")))
 
         # For all, loop through keys and separate into multiple keys if there are multiple pfams
         new_fxns = {}


### PR DESCRIPTION
Add better handling of string interpretation for getting functional annotations from protein reports (fixes #31).

Restructure the MetaPAggregator to source functional annotations and associated counts directly from peptide report so we don't double count spectra (fixes #33).

I tested this locally as best I could.  Once pushed I will monitor in dev.
