### PR TITLE
Include required `type` field when creating `functional_annotation_agg` documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.venv
 # IntelliJ IDEA project files
 .idea
+# Python cache files
+__pycache__

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Here's how you can run the tests:
 
 1. Run the tests
    ```shell
-   pytest
+   pytest --doctest-modules
    ```
+   > The `--doctest-modules` option tells pytest that we want it to also find and run doctests defined in our modules.
 2. See the test results in the console
 
 ## Deployment

--- a/generate_functional_agg.py
+++ b/generate_functional_agg.py
@@ -7,6 +7,27 @@ from signal import signal, SIGINT
 stop = False
 
 
+def make_functional_annotation_agg_member(
+    was_generated_by: str,
+    gene_function_id: str,
+    count: int,
+) -> dict:
+    r"""
+    Returns a dictionary representing a instance of the `FunctionalAnnotationAggMember`
+    class defined in the NMDC Schema (as of `nmdc-version` version `11.7.0`).
+    Docs: https://microbiomedata.github.io/nmdc-schema/FunctionalAnnotationAggMember/
+
+    >>> make_functional_annotation_agg_member("wgb", "gfi", 123)
+    {'was_generated_by': 'wgb', 'gene_function_id': 'gfi', 'count': 123, 'type': 'nmdc:FunctionalAnnotationAggMember'}
+    """
+    return {
+        "was_generated_by": was_generated_by,
+        "gene_function_id": gene_function_id,
+        "count": count,
+        "type": "nmdc:FunctionalAnnotationAggMember",
+    }
+
+
 def sig_handler(signalnumber, frame):
     global stop
     stop = True
@@ -118,11 +139,11 @@ class MetaGenomeFuncAgg():
 
         rows = []
         for func, ct in cts.items():
-            rec = {
-                'was_generated_by': id,
-                'gene_function_id': func,
-                'count': ct
-                }
+            rec = make_functional_annotation_agg_member(
+                was_generated_by=id,
+                gene_function_id=func,
+                count=ct,
+            )
             rows.append(rec)
         print(f' - {len(rows)} terms')
         return rows

--- a/generate_functional_agg.py
+++ b/generate_functional_agg.py
@@ -13,7 +13,7 @@ def make_functional_annotation_agg_member(
     count: int,
 ) -> dict:
     r"""
-    Returns a dictionary representing a instance of the `FunctionalAnnotationAggMember`
+    Returns a dictionary representing an instance of the `FunctionalAnnotationAggMember`
     class defined in the NMDC Schema (as of `nmdc-version` version `11.7.0`).
     Docs: https://microbiomedata.github.io/nmdc-schema/FunctionalAnnotationAggMember/
 


### PR DESCRIPTION
On this branch, I updated code that creates a dictionary representing an instance of the `FunctionalAnnotationAggMember` class, so that the dictionary includes the `type` field (which, according to the [NMDC Schema](https://microbiomedata.github.io/nmdc-schema/FunctionalAnnotationAggMember/), is a required field).

I broke the code out into a function (having a name, type hints, docstring, and doctest) in an attempt to make it more apparent to the reader what is happening. The dictionary returned by the function includes the previously-missing `type` field.