### PR TITLE
fix bug: remove only scan gff with ko and strip off the newline characters

### DIFF
--- a/generate_functional_agg.py
+++ b/generate_functional_agg.py
@@ -50,8 +50,8 @@ class AnnotationLine():
 
         for anno in annotations:
             if anno.startswith("ko="):
-                kos = anno[3:].replace("KO:", "KEGG.ORTHOLOGY:")
-                self.kegg = [ko.strip() for ko in kos.split(',')]
+                processed_kos = anno[3:].replace("KO:", "KEGG.ORTHOLOGY:")
+                self.kegg = [ko.strip() for ko in processed_kos.split(',')]
             elif anno.startswith("cog="):
                 self.cogs = ['COG:' + cog_id.strip() for cog_id in anno[4:].split(',')]
             elif anno.startswith("product="):

--- a/generate_functional_agg.py
+++ b/generate_functional_agg.py
@@ -43,24 +43,23 @@ class AnnotationLine():
         self.ec_numbers = None
         self.pfams = None
 
-        if line.find("ko=") > 0:
-            annotations = line.split("\t")[8].split(";")
-            self.id = annotations[0][3:]
-            if filter and self.id not in filter:
-                return
+        annotations = line.split("\t")[8].split(";")
+        self.id = annotations[0][3:]
+        if filter and self.id not in filter:
+            return
 
-            for anno in annotations:
-                if anno.startswith("ko="):
-                    kos = anno[3:].replace("KO:", "KEGG.ORTHOLOGY:")
-                    self.kegg = kos.rstrip().split(',')
-                elif anno.startswith("cog="):
-                    self.cogs = ['COG:' + cog_id for cog_id in anno[4:].split(',')]
-                elif anno.startswith("product="):
-                    self.product = anno[8:]
-                elif anno.startswith("ec_number="):
-                    self.ec_numbers = anno[10:].split(",")
-                elif anno.startswith("pfam="):
-                    self.pfams = ['PFAM:' + pfam_id for pfam_id in anno[5:].split(",")]
+        for anno in annotations:
+            if anno.startswith("ko="):
+                kos = anno[3:].replace("KO:", "KEGG.ORTHOLOGY:")
+                self.kegg = [ko.strip() for ko in kos.split(',')]
+            elif anno.startswith("cog="):
+                self.cogs = ['COG:' + cog_id.strip() for cog_id in anno[4:].split(',')]
+            elif anno.startswith("product="):
+                self.product = anno[8:]
+            elif anno.startswith("ec_number="):
+                self.ec_numbers = anno[10:].split(",")
+            elif anno.startswith("pfam="):
+                self.pfams = ['PFAM:' + pfam_id.strip() for pfam_id in anno[5:].split(",")]
 
 
 class MetaGenomeFuncAgg():


### PR DESCRIPTION
* Fix count number error: Remove line 46 (and the surrounding if line.find("ko=") block) so that all lines are parsed, regardless of whether ko= is present.

If any GFF line ends with the PFAM field, the last PFAM ID will likely include a newline (\n) unless explicitly stripped.

* Fix newline trailing character: Apply .strip() to PFAM and COG and KO.