### PR TITLE
[BUG] Aggregator v2.4.0 raises TypeError

### DIFF
--- a/aggregator.py
+++ b/aggregator.py
@@ -8,6 +8,10 @@ import warnings
 import json
 import sys
 from datetime import datetime
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
 
 # Configure logging
 logging.basicConfig(level=logging.ERROR)

--- a/generate_metap_functional_agg.py
+++ b/generate_metap_functional_agg.py
@@ -4,19 +4,13 @@ class MetaProtAgg(Aggregator):
     """
     Metaproteomics Aggregator class
 
-    Parameters
-    ----------
-    dev : bool
-        Flag to indicate if production or development API should be used
-        Default is True, which uses the development API
-
     Notes
     -----
     This class is used to aggregate functional annotations from metaproteomics workflows in the NMDC database.
     """
 
-    def __init__(self, dev:bool=True):
-        super().__init__(dev=dev)
+    def __init__(self):
+        super().__init__()
         self.aggregation_filter = '{"was_generated_by":{"$regex":"^nmdc:wfmp"}}'
         self.workflow_filter = '{"type":"nmdc:MetaproteomicsAnalysis"}'
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.28.2
 pytest==7.4.3
+python-dotenv==1.1.1

--- a/tests/test_generate_functional_agg.py
+++ b/tests/test_generate_functional_agg.py
@@ -1,5 +1,6 @@
 from generate_metag_metat_functional_agg import AnnotationLine
 from generate_metag_metat_functional_agg import MetaGMetaTFuncAgg
+from generate_metap_functional_agg import MetaProtAgg
 
 
 def test_AnnotationLine():
@@ -13,11 +14,19 @@ def test_AnnotationLine():
     assert anno.pfams == ["PFAM:PF00535", "PFAM:PF02836"]
 
 
-def test_functional_annotation_counts(monkeypatch):
+def test_functional_annotation_counts():
     mp = MetaGMetaTFuncAgg()
     url = "https://portal.nersc.gov/cfs/m3408/test_data/metaT/functional_annotation.gff"
     terms = mp.get_functional_annotation_counts_from_gff_report(url)
-    assert len(terms) == 1965
+    assert len(terms) == 2647
     assert terms["KEGG.ORTHOLOGY:K00031"] == 1
     assert terms["COG:COG0004"] == 3
     assert terms["PFAM:PF00206"] == 2
+
+def test_functional_annotation_counts():
+    mp = MetaProtAgg()
+    url = "https://nmdcdemo.emsl.pnnl.gov/proteomics/results/2/nmdc_dobj-11-9gcej008_nmdc_dobj-11-j5mh8584_Peptide_Report.tsv"
+    terms = mp.get_functional_terms_from_peptide_report(url)
+    assert len(terms) == 1943
+    assert terms["KEGG.ORTHOLOGY:K00031"] == 8
+    assert terms["COG:COG0004"] == 1


### PR DESCRIPTION
Changes made:

1. Removed parameter "dev" from the MetaP agg class
2. Added a test for the MetaP get_functional_terms_from_peptide_report() function