### PR TITLE
Modify how we check if records have been previously aggregated

### DIFF
--- a/agg.sh
+++ b/agg.sh
@@ -6,8 +6,8 @@ if [ -z $LOG_FILE ] ; then
 fi
 
 if [ -z $POLL_TIME ] ; then
-        # DEFAULT every 4 hours
-	POLL_TIME=14400
+        # DEFAULT every 8 hours
+        POLL_TIME=28800
 fi
 
 while true ; do

--- a/agg.sh
+++ b/agg.sh
@@ -6,8 +6,8 @@ if [ -z $LOG_FILE ] ; then
 fi
 
 if [ -z $POLL_TIME ] ; then
-        # DEFAULT every 8 hours
-        POLL_TIME=28800
+        # DEFAULT every 4 hours
+	POLL_TIME=14400
 fi
 
 while true ; do

--- a/aggregator.py
+++ b/aggregator.py
@@ -351,7 +351,6 @@ class Aggregator(ABC):
 
             # Check if records already exist before submitting
             if self.check_for_aggregation_records(mp_wf_rec["id"]):
-                logger.info(f"Aggregation records already exist for workflow: {mp_wf_rec['id']}, skipping submission")
                 continue
 
             response = self.submit_json_records(json_record_full)
@@ -360,8 +359,8 @@ class Aggregator(ABC):
                     f"Error submitting the aggregation records for the workflow: {mp_wf_rec['id']}, Response code: {response}"
                 )
             if response == 200:
-                logger.info(
-                    f"Submitted aggregation records for the workflow: {mp_wf_rec['id']}"
+                print(
+                    "Submitted aggregation records for the workflow: ", mp_wf_rec["id"]
                 )
 
     def sweep_success(self):

--- a/aggregator.py
+++ b/aggregator.py
@@ -106,7 +106,7 @@ class Aggregator(ABC):
             )
         self.nmdc_api_token = token_response["access_token"]
 
-    def get_results(self, collection: str, filter="", max_page_size=100, fields="", return_all=True, debug=False):
+    def get_results(self, collection: str, filter="", max_page_size=100, fields="", return_all=True):
         """General function to get results from the API using the collection endpoint with optional filter and fields
 
         Parameters

--- a/tests/test_generate_functional_agg.py
+++ b/tests/test_generate_functional_agg.py
@@ -23,10 +23,15 @@ def test_functional_annotation_counts():
     assert terms["COG:COG0004"] == 3
     assert terms["PFAM:PF00206"] == 2
 
-def test_functional_annotation_counts():
+def test_functional_annotation_counts_metaproteomics():
     mp = MetaProtAgg()
     url = "https://nmdcdemo.emsl.pnnl.gov/proteomics/results/2/nmdc_dobj-11-9gcej008_nmdc_dobj-11-j5mh8584_Peptide_Report.tsv"
     terms = mp.get_functional_terms_from_peptide_report(url)
     assert len(terms) == 1943
     assert terms["KEGG.ORTHOLOGY:K00031"] == 8
     assert terms["COG:COG0004"] == 1
+
+def test_check_for_aggregation_records():
+    mp = MetaProtAgg()
+    assert mp.check_for_aggregation_records("nmdc:wfmp-11-yafgh176.1")
+    assert not mp.check_for_aggregation_records("nonexistent_wf_id")


### PR DESCRIPTION
Fixes #51.

Duplicate key errors were being made because the method `get_previously_aggregated_workflow_ids` was not returning all workflow ids (see https://github.com/microbiomedata/nmdc-aggregator/issues/53). I think it's a runtime/pagination issue and @hesspnnl is going to dig into and document it separately from the aggregator (I reproduced it outside of this repo).

To move forward, I restructured how we check if a workflow has been previously submitted. It's not perfect, but for each workflow id, now there's a single API call to check if that ID exists in the functional_annotation_agg collection (via the new  `check_for_aggregation_records` method).  If it exists, it doesn't try to generate new records.  Personally I think there should be a single endpoint that spits out non-aggregated workflow ids so we don't have to ping the API so much (see https://github.com/microbiomedata/nmdc-aggregator/issues/38).  Until then, this should work (it does locally).